### PR TITLE
Fix typo in 1.1.0 release notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 <td>2</td>
 <td>Juni 2019</td>
 <td><a href="https://bastl-instruments.github.io/thyme/downloads/thyme_firmware_1.1.0.mid">MIDI File</a></td>
-<td><b>Fixed Bug</b>: Chrip in transition from lowpass to highpass<br/><b>Fixed Bug</b>: Headphone pot does not react sometimes<br/><b>Fixed Bug</b>: Mitigate flash corruption (requires hardware 1.1 to be effective)<br/><b>Feature</b>: Interpretation of MIDI start/stop messages can be disabled<br/><b>Feature</b>: Set to half/double tape speed with button combination<br/><b>Feature</b>: Add triplet as a quantization option (robots and delay length)<br/><b>Feature</b>: Lower minimum speed for oscillator type robots<br/></td>
+<td><b>Fixed Bug</b>: Chirp in transition from lowpass to highpass<br/><b>Fixed Bug</b>: Headphone pot does not react sometimes<br/><b>Fixed Bug</b>: Mitigate flash corruption (requires hardware 1.1 to be effective)<br/><b>Feature</b>: Interpretation of MIDI start/stop messages can be disabled<br/><b>Feature</b>: Set to half/double tape speed with button combination<br/><b>Feature</b>: Add triplet as a quantization option (robots and delay length)<br/><b>Feature</b>: Lower minimum speed for oscillator type robots<br/></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
I keep checking this page for updates and seeing the typo every time is killing me. Please merge ASAP.